### PR TITLE
feat: add accept all functionality to banner

### DIFF
--- a/src/consent-manager/banner.tsx
+++ b/src/consent-manager/banner.tsx
@@ -5,18 +5,23 @@ import fontStyles from './font-styles'
 const Root = styled<{ backgroundColor: string; textColor: string }, 'div'>('div')`
   ${fontStyles};
   position: relative;
-  padding: 8px;
+  padding: 16px;
   padding-right: 40px;
   background: ${props => props.backgroundColor};
   color: ${props => props.textColor};
   text-align: center;
   font-size: 12px;
   line-height: 1.3;
+  border-radius: 4px;
 `
 
 const Content = styled('div')`
-  a,
-  button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: left;
+
+  a {
     display: inline;
     padding: 0;
     border: none;
@@ -26,13 +31,39 @@ const Content = styled('div')`
     text-decoration: underline;
     cursor: pointer;
   }
+
+  button {
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-right: 8px;
+    border: none;
+  }
+`
+
+const Action = styled('div')`
+  display: flex;
 `
 
 const P = styled('p')`
   margin: 0;
+  max-width: 65%;
   &:not(:last-child) {
     margin-bottom: 6px;
   }
+`
+
+const AcceptButton = styled('button')`
+  background-color: #f77857;
+  color: #ffffff;
+  font-weight: 600;
+  padding: 8px;
+`
+
+const EditButton = styled('button')`
+  background-color: #f0eeeb;
+  color: #5c5a59;
+  font-weight: 600;
+  padding: 8px;
 `
 
 const CloseButton = styled('button')`
@@ -53,8 +84,10 @@ const CloseButton = styled('button')`
 interface Props {
   innerRef: (node: HTMLElement | null) => void
   onClose: () => void
+  onAccept: () => void
   onChangePreferences: () => void
   content: React.ReactNode
+  acceptContent: React.ReactNode
   subContent: React.ReactNode
   backgroundColor: string
   textColor: string
@@ -67,8 +100,10 @@ export default class Banner extends PureComponent<Props> {
     const {
       innerRef,
       onClose,
+      onAccept,
       onChangePreferences,
       content,
+      acceptContent,
       subContent,
       backgroundColor,
       textColor
@@ -78,11 +113,15 @@ export default class Banner extends PureComponent<Props> {
       <Root innerRef={innerRef} backgroundColor={backgroundColor} textColor={textColor}>
         <Content>
           <P>{content}</P>
-          <P>
-            <button type="button" onClick={onChangePreferences}>
+
+          <Action>
+            <AcceptButton type="button" onClick={onAccept}>
+              {acceptContent}
+            </AcceptButton>
+            <EditButton type="button" onClick={onChangePreferences}>
               {subContent}
-            </button>
-          </P>
+            </EditButton>
+          </Action>
         </Content>
 
         <CloseButton type="button" title="Close" aria-label="Close" onClick={onClose}>

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -39,6 +39,7 @@ interface ContainerProps {
   isConsentRequired: boolean
   implyConsentOnInteraction: boolean
   bannerContent: React.ReactNode
+  bannerAcceptContent: React.ReactNode
   bannerSubContent: React.ReactNode
   bannerTextColor: string
   bannerBackgroundColor: string
@@ -154,6 +155,16 @@ const Container: React.FC<ContainerProps> = props => {
     return toggleBanner(false)
   }
 
+  const onAccept = () => {
+    const truePreferences = Object.keys(props.preferences).reduce((acc, category) => {
+      acc[category] = true
+      return acc
+    }, {})
+
+    props.setPreferences(truePreferences)
+    return props.saveConsent()
+  }
+
   const handleCategoryChange = (category: string, value: boolean) => {
     props.setPreferences({
       [category]: value
@@ -192,8 +203,10 @@ const Container: React.FC<ContainerProps> = props => {
         <Banner
           innerRef={current => (banner = { current })}
           onClose={onClose}
+          onAccept={onAccept}
           onChangePreferences={() => toggleDialog(true)}
           content={props.bannerContent}
+          acceptContent={props.bannerAcceptContent}
           subContent={props.bannerSubContent}
           textColor={props.bannerTextColor}
           backgroundColor={props.bannerBackgroundColor}

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -21,7 +21,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     cookieDomain: undefined,
     customCategories: undefined,
     bannerTextColor: '#fff',
-    bannerSubContent: 'You can change your preferences at any time.',
+    bannerAcceptContent: 'Accept All',
+    bannerSubContent: 'Manage Preferences',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     cancelDialogTitle: 'Are you sure you want to cancel?',
@@ -36,6 +37,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       implyConsentOnInteraction,
       cookieDomain,
       bannerContent,
+      bannerAcceptContent,
       bannerSubContent,
       bannerTextColor,
       bannerBackgroundColor,
@@ -89,6 +91,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
                 implyConsentOnInteraction ?? ConsentManager.defaultProps.implyConsentOnInteraction
               }
               bannerContent={bannerContent}
+              bannerAcceptContent={bannerAcceptContent}
               bannerSubContent={bannerSubContent}
               bannerTextColor={bannerTextColor || ConsentManager.defaultProps.bannerTextColor}
               bannerBackgroundColor={

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface ConsentManagerProps {
   implyConsentOnInteraction?: boolean
   cookieDomain?: string
   bannerContent: React.ReactNode
+  bannerAcceptContent?: string
   bannerSubContent?: string
   bannerTextColor?: string
   bannerBackgroundColor?: string

--- a/stories/0-consent-manager.stories.tsx
+++ b/stories/0-consent-manager.stories.tsx
@@ -23,7 +23,7 @@ const bannerContent = (
     .
   </span>
 )
-const bannerSubContent = 'You can manage your preferences here!'
+const bannerSubContent = 'Manage Preferences'
 const preferencesDialogTitle = 'Website Data Collection Preferences'
 const preferencesDialogContent = (
   <div>


### PR DESCRIPTION
Adds 'accept all' functionality to segment consent manager banner

![image](https://user-images.githubusercontent.com/2679128/102339474-7f19b400-3f95-11eb-854d-04fa3467ccc1.png)
