### PR TITLE
fix: add check for first time rejecting users so we also save their p…

### DIFF
--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -295,8 +295,12 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
 
       const newDestinations = getNewDestinations(destinations, destinationPreferences)
 
+      // Additional check so that we also save first time preferences
+      const preferenceCookie = loadPreferences()
+      const hasPreferenceCookie = preferenceCookie && Object.keys(preferenceCookie).length > 0
+
       // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
-      if (prevState.havePreferencesChanged || newDestinations.length > 0) {
+      if (prevState.havePreferencesChanged || newDestinations.length > 0 || !hasPreferenceCookie) {
         savePreferences({ destinationPreferences, customPreferences, cookieDomain })
         conditionallyLoadAnalytics({
           writeKey,


### PR DESCRIPTION
Ticket: https://allaboutme.atlassian.net/browse/WEB-1092

Bug analysis:
We found out that the issue was us not saving any cookie if user didn't interact with the form and directly proceeds with "Save". 

The root cause was found in `handleSaveConsent` where there's a check before saving user's preferences to not unnecessarily reload the page. It would only save if there has been changes done **actively** to the preferences. But it was not checking the case if we supplied the `initialPreferences` for the user in which case the user did not need to actively change the form values.

Proposed solution:
Check before saving preferences if there is a cookie in the user's browser, if no, then save the preferences.