### PR TITLE
chore: send custom events to MixPanel

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
   "dependencies": {
     "@segment/in-regions": "^1.2.0",
     "@segment/top-domain": "^3.0.0",
+    "dotenv": "^9.0.2",
     "emotion": "^9.1.2",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
     "lodash": "^4.17.11",
+    "mixpanel-browser": "^2.41.0",
     "nanoid": "^1.0.2",
     "prop-types": "^15.6.1",
     "react-emotion": "^9.1.2"

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -1,4 +1,5 @@
 import { Component } from 'react'
+import mixpanel from 'mixpanel-browser'
 import { loadPreferences, savePreferences } from './preferences'
 import fetchDestinations from './fetch-destinations'
 import conditionallyLoadAnalytics from './analytics'
@@ -171,6 +172,10 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
   }
 
   initialise = async () => {
+    const mixpanelTracking = process.env.MIXPANEL_TRACKING
+    if (mixpanelTracking) {
+      mixpanel.track('banner_viewed')
+    }
     const {
       writeKey,
       otherWriteKeys = ConsentManagerBuilder.defaultProps.otherWriteKeys,

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -173,7 +173,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
 
   initialise = async () => {
     const mixpanelTracking = process.env.MIXPANEL_TRACKING
-    if (mixpanelTracking) {
+    if (mixpanelTracking === 'true') {
       mixpanel.track('banner_viewed')
     }
     const {

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -1,6 +1,7 @@
 import EventEmitter from 'events'
 import React from 'react'
 import styled from 'react-emotion'
+import mixpanel from 'mixpanel-browser'
 import Banner from './banner'
 import PreferenceDialog from './preference-dialog'
 import CancelDialog from './cancel-dialog'
@@ -171,7 +172,12 @@ const Container: React.FC<ContainerProps> = props => {
     return toggleBanner(false)
   }
 
+  const mixpanelTracking = process.env.MIXPANEL_TRACKING
+
   const onAccept = () => {
+    if (mixpanelTracking) {
+      mixpanel.track('banner_accept_clicked')
+    }
     const truePreferences = Object.keys(props.preferences).reduce((acc, category) => {
       acc[category] = true
       return acc
@@ -189,6 +195,13 @@ const Container: React.FC<ContainerProps> = props => {
     return props.saveConsent()
   }
 
+  const onChangePreferences = () => {
+    if (mixpanelTracking) {
+      mixpanel.track('banner_settings_clicked')
+    }
+    toggleDialog(true)
+  }
+
   const handleCategoryChange = (category: string, value: boolean) => {
     props.setPreferences({
       [category]: value
@@ -196,6 +209,9 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   const handleSave = () => {
+    if (mixpanelTracking) {
+      mixpanel.track('banner_settings_saved_clicked')
+    }
     toggleDialog(false)
 
     props.saveConsent()
@@ -231,7 +247,7 @@ const Container: React.FC<ContainerProps> = props => {
             onClose={onClose}
             onAccept={onAccept}
             onReject={onReject}
-            onChangePreferences={() => toggleDialog(true)}
+            onChangePreferences={onChangePreferences}
             content={props.bannerContent}
             acceptContent={props.bannerAcceptContent}
             rejectContent={props.bannerRejectContent}

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -175,7 +175,7 @@ const Container: React.FC<ContainerProps> = props => {
   const mixpanelTracking = process.env.MIXPANEL_TRACKING
 
   const onAccept = () => {
-    if (mixpanelTracking) {
+    if (mixpanelTracking === 'true') {
       mixpanel.track('banner_accept_clicked')
     }
     const truePreferences = Object.keys(props.preferences).reduce((acc, category) => {
@@ -196,7 +196,7 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   const onChangePreferences = () => {
-    if (mixpanelTracking) {
+    if (mixpanelTracking === 'true') {
       mixpanel.track('banner_settings_clicked')
     }
     toggleDialog(true)
@@ -209,7 +209,7 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   const handleSave = () => {
-    if (mixpanelTracking) {
+    if (mixpanelTracking === 'true') {
       mixpanel.track('banner_settings_saved_clicked')
     }
     toggleDialog(false)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,11 @@ type Nav = Navigator & {
   msDoNotTrack?: Navigator['doNotTrack']
 }
 
+import mixpanel from 'mixpanel-browser'
+mixpanel.init(process.env.MIXPANEL_PROJECT_TOKEN)
+
 export function doNotTrack(): boolean | null {
-  
-  if (typeof window !== 'undefined' && (window.navigator || navigator)) { 
+  if (typeof window !== 'undefined' && (window.navigator || navigator)) {
     const nav = navigator as Nav
 
     let doNotTrackValue = nav.doNotTrack || window.doNotTrack || nav.msDoNotTrack

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const path = require('path')
 const webpack = require('webpack')
 const pkg = require('./package.json')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5972,6 +5972,11 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
   integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
 
+dotenv@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
+  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
+
 downshift@^1.16.0:
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.14.tgz#98b04614cad2abc4297d0d02b50ff2c48b2625e7"
@@ -10526,6 +10531,11 @@ mixin-object@^2.0.1:
   dependencies:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
+
+mixpanel-browser@^2.41.0:
+  version "2.41.0"
+  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.41.0.tgz#d49753b4e4a7e6ddd18c126be4a917fff4ce3039"
+  integrity sha512-IEuc9cH44hba9a3KEyulXINLn+gpFqluBDo7xiTk1h3j111dmmsctaE6tUzZYxgGLVqeNhTpsccdliOeX24Wlw==
 
 mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"


### PR DESCRIPTION
Ticket: https://allaboutme.atlassian.net/browse/WEB-1095

- Add mixpanel
- Track click events to accurately observe customer behavior with consent manager

To test locally, you'll need:
1. Add .env with environment variables for local development, to be found under the shared secrets in 1Password.
2. Interact with consent manager in storybook.
3. Check in the "Tilda - Development" account on mixpanel for sent events, link to [live view](https://mixpanel.com/report/2353056/view/2898088/live).