### PR TITLE
fix: retrieval for mixpanel project token and flag

### DIFF
--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -78,6 +78,11 @@ interface Props {
    * CDN to fetch list of integrations from
    */
   cdnHost?: string
+
+  /**
+   * Flag if mixpanel events should be sent
+   */
+  mixpanelTracking?: boolean
 }
 
 interface RenderProps {
@@ -172,8 +177,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
   }
 
   initialise = async () => {
-    const mixpanelTracking = process.env.MIXPANEL_TRACKING
-    if (mixpanelTracking === 'true') {
+    if (this.props.mixpanelTracking) {
       mixpanel.track('banner_viewed')
     }
     const {

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -66,6 +66,7 @@ interface ContainerProps {
   cancelDialogContent: React.ReactNode
   workspaceAddedNewDestinations?: boolean
   defaultDestinationBehavior?: DefaultDestinationBehavior
+  mixpanelTracking?: boolean
 }
 
 function normalizeDestinations(destinations: Destination[]) {
@@ -172,10 +173,8 @@ const Container: React.FC<ContainerProps> = props => {
     return toggleBanner(false)
   }
 
-  const mixpanelTracking = process.env.MIXPANEL_TRACKING
-
   const onAccept = () => {
-    if (mixpanelTracking === 'true') {
+    if (props.mixpanelTracking) {
       mixpanel.track('banner_accept_clicked')
     }
     const truePreferences = Object.keys(props.preferences).reduce((acc, category) => {
@@ -196,7 +195,7 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   const onChangePreferences = () => {
-    if (mixpanelTracking === 'true') {
+    if (props.mixpanelTracking) {
       mixpanel.track('banner_settings_clicked')
     }
     toggleDialog(true)
@@ -209,7 +208,7 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   const handleSave = () => {
-    if (mixpanelTracking === 'true') {
+    if (props.mixpanelTracking) {
       mixpanel.track('banner_settings_saved_clicked')
     }
     toggleDialog(false)

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import mixpanel from 'mixpanel-browser'
 import ConsentManagerBuilder from '../consent-manager-builder'
 import Container from './container'
 import { ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES } from './categories'
@@ -49,8 +50,12 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       customCategories,
       defaultDestinationBehavior,
       cdnHost,
-      onError
+      onError,
+      mixpanelToken,
+      mixpanelTracking
     } = this.props
+
+    mixpanel.init(mixpanelToken)
 
     return (
       <ConsentManagerBuilder
@@ -64,6 +69,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
         customCategories={customCategories}
         defaultDestinationBehavior={defaultDestinationBehavior}
         cdnHost={cdnHost}
+        mixpanelTracking={mixpanelTracking}
       >
         {({
           destinations,
@@ -106,6 +112,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
               havePreferencesChanged={havePreferencesChanged}
               defaultDestinationBehavior={defaultDestinationBehavior}
               workspaceAddedNewDestinations={workspaceAddedNewDestinations}
+              mixpanelTracking={mixpanelTracking}
             />
           )
         }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,6 @@ type Nav = Navigator & {
   msDoNotTrack?: Navigator['doNotTrack']
 }
 
-import mixpanel from 'mixpanel-browser'
-mixpanel.init(process.env.MIXPANEL_PROJECT_TOKEN)
-
 export function doNotTrack(): boolean | null {
   if (typeof window !== 'undefined' && (window.navigator || navigator)) {
     const nav = navigator as Nav

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,4 +97,6 @@ export interface ConsentManagerProps {
   customCategories?: CustomCategories
   defaultDestinationBehavior?: DefaultDestinationBehavior
   cdnHost?: string
+  mixpanelToken?: string
+  mixpanelTracking?: boolean
 }

--- a/stories/8-mixpanel-custom-events.stories.tsx
+++ b/stories/8-mixpanel-custom-events.stories.tsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import cookies from 'js-cookie'
+import { Pane, Heading, Paragraph, Button } from 'evergreen-ui'
+import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
+import { storiesOf } from '@storybook/react'
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { Preferences } from '../src/types'
+import CookieView from './components/CookieView'
+import inRegions from '@segment/in-regions'
+import { CloseBehavior } from '../src/consent-manager/container'
+
+const bannerContent = (
+  <span>
+    We use cookies (and other similar technologies) to collect data to improve your experience on
+    our site. By using our website, you’re agreeing to the collection of data as described in our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </span>
+)
+const bannerSubContent = 'You can manage your preferences here!'
+const preferencesDialogTitle = 'Website Data Collection Preferences'
+const preferencesDialogContent = (
+  <div>
+    <p>
+      Segment uses data collected by cookies and JavaScript libraries to improve your browsing
+      experience, analyze site traffic, deliver personalized advertisements, and increase the
+      overall performance of our site.
+    </p>
+    <p>
+      By using our website, you’re agreeing to our{' '}
+      <a
+        href="https://segment.com/docs/legal/website-data-collection-policy/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Website Data Collection Policy
+      </a>
+      .
+    </p>
+    <p>
+      The table below outlines how we use this data by category. To opt out of a category of data
+      collection, select “No” and save your preferences.
+    </p>
+  </div>
+)
+const cancelDialogTitle = 'Are you sure you want to cancel?'
+const cancelDialogContent = (
+  <div>
+    Your preferences have not been saved. By continuing to use our website, you’re agreeing to our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </div>
+)
+
+const ConsentManagerMixpanel = (props: { enabled: boolean }) => {
+  const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  const cleanup = onPreferencesSaved(preferences => {
+    updatePrefs(preferences)
+  })
+
+  React.useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  })
+
+  const inCA = inRegions(['CA'])
+  const inEU = inRegions(['EU'])
+  const shouldRequireConsent = inRegions(['CA', 'EU'])
+  const caDefaultPreferences = {
+    advertising: false,
+    marketingAndAnalytics: true,
+    functional: true
+  }
+  const euDefaultPreferences = {
+    advertising: false,
+    marketingAndAnalytics: false,
+    functional: false
+  }
+
+  const closeBehavior = inCA()
+    ? _categories => caDefaultPreferences
+    : inEU()
+    ? CloseBehavior.DENY
+    : CloseBehavior.ACCEPT
+
+  const initialPreferences = inCA()
+    ? caDefaultPreferences
+    : inEU()
+    ? euDefaultPreferences
+    : undefined
+
+  return (
+    <Pane>
+      <ConsentManager
+        writeKey="n2DAIaakJzCUq0saLY0LMcm9dKsqCZvU"
+        bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
+        preferencesDialogTitle={preferencesDialogTitle}
+        preferencesDialogContent={preferencesDialogContent}
+        cancelDialogTitle={cancelDialogTitle}
+        cancelDialogContent={cancelDialogContent}
+        closeBehavior={closeBehavior}
+        shouldRequireConsent={shouldRequireConsent}
+        initialPreferences={initialPreferences}
+        mixpanelToken="7b189d5f466a3d0a3027c71d1726fa18"
+        mixpanelTracking={props.enabled}
+      />
+
+      <Pane marginX={100} marginTop={20}>
+        <Heading> Cute Cats </Heading>
+        <Pane display="flex">
+          <iframe
+            src="https://giphy.com/embed/JIX9t2j0ZTN9S"
+            width="480"
+            height="480"
+            frameBorder="0"
+          />
+
+          <iframe
+            src="https://giphy.com/embed/yFQ0ywscgobJK"
+            width="398"
+            height="480"
+            frameBorder="0"
+          />
+        </Pane>
+        <Button onClick={() => window.analytics.track('Send Track Event Clicked')}>
+          Send Track Event
+        </Button>
+
+        <Paragraph marginTop={20}>
+          This example is to show the custom events we track with Mixpanel.
+        </Paragraph>
+        <p>
+          <div>
+            <Heading>Current Preferences</Heading>
+            <SyntaxHighlighter language="json" style={docco}>
+              {JSON.stringify(prefs, null, 2)}
+            </SyntaxHighlighter>
+          </div>
+          <Button marginRight={20} onClick={openConsentManager}>
+            Change Cookie Preferences
+          </Button>
+          <Button
+            onClick={() => {
+              cookies.remove('tracking-preferences')
+              window.location.reload()
+            }}
+          >
+            Clear
+          </Button>
+        </p>
+      </Pane>
+      <CookieView />
+    </Pane>
+  )
+}
+
+storiesOf('Mixpanel custom events', module)
+  .add(`Tracking enabled`, () => <ConsentManagerMixpanel enabled={true} />)
+  .add(`Tracking disabled`, () => <ConsentManagerMixpanel enabled={false} />)


### PR DESCRIPTION
Ticket: https://allaboutme.atlassian.net/browse/WEB-1095

This PR fixes the non-passing of environment variables from our web app. Now the mixpanel specific token and flag are passed down as props.

To test:
1. Interact with consent manager in Mixpalen story in storybook
2. Observe events (not) received on Mixpanel Tilda - Development: https://mixpanel.com/report/2353056/view/2898088/live